### PR TITLE
[FIX] Fix versions

### DIFF
--- a/ufazien-cli-js/package-lock.json
+++ b/ufazien-cli-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ufazien-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ufazien-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",

--- a/ufazien-cli-js/package.json
+++ b/ufazien-cli-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ufazien-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/ufazien-cli-py/pyproject.toml
+++ b/ufazien-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ufazien-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Command-line interface for deploying web applications on Ufazien platform"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/ufazien-cli-py/src/ufazien/__init__.py
+++ b/ufazien-cli-py/src/ufazien/__init__.py
@@ -2,7 +2,7 @@
 Ufazien CLI - Command-line interface for deploying web applications on Ufazien platform.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from ufazien.client import UfazienAPIClient
 


### PR DESCRIPTION
This pull request updates the version number for both the JavaScript and Python packages of the Ufazien CLI from 0.2.0 to 0.2.1. No other significant changes are included.

- Version bump to 0.2.1:
  * Updated the version in `package.json` and `package-lock.json` for the JavaScript CLI package. [[1]](diffhunk://#diff-648bcfa8f9d6ebbfae03c8d1f388c2f5b18a5cb6d16a979062306babadd244b3L3-R3) [[2]](diffhunk://#diff-92edcad5a7bbc0843eebe0cbdb06f4f69a631acfc4dc99ec3e87e194c8172a9cL3-R9)
  * Updated the version in `pyproject.toml` and `__init__.py` for the Python CLI package. [[1]](diffhunk://#diff-e1e0e9c74e366e9300694042b6fc6082c6859c06c83fae0eda50e680e187b244L7-R7) [[2]](diffhunk://#diff-527b11ece2f7ed237c5080959c506323ee69914582255db258c3debd980ef956L5-R5)