### PR TITLE
[FEAT] Add empty project structure for already existing projects

### DIFF
--- a/ufazien-cli-js/package-lock.json
+++ b/ufazien-cli-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ufazien-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ufazien-cli",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",

--- a/ufazien-cli-js/package.json
+++ b/ufazien-cli-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ufazien-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/ufazien-cli-js/src/project.ts
+++ b/ufazien-cli-js/src/project.ts
@@ -164,6 +164,116 @@ build/
   }
 }
 
+export function createReadmeSection(
+  projectDir: string,
+  websiteType: string,
+  websiteName: string,
+  buildFolder?: string
+): void {
+  const readmePath = path.join(projectDir, 'README.md');
+  
+  if (websiteType === 'build') {
+    if (!fs.existsSync(readmePath)) {
+      const readmeContent = `# ${websiteName}
+
+This project is configured for deployment to Ufazien Hosting.
+
+## Build and Deploy
+
+1. Build your project (this will create a \`dist\` or \`build\` folder):
+\`\`\`bash
+npm run build
+# or
+yarn build
+# or
+pnpm build
+\`\`\`
+
+2. Deploy to Ufazien:
+\`\`\`bash
+ufazienjs deploy
+\`\`\`
+
+The deployment will automatically upload the contents of your build folder.
+`;
+      fs.writeFileSync(readmePath, readmeContent);
+    } else {
+      const existingContent = fs.readFileSync(readmePath, 'utf-8');
+      if (!existingContent.includes('Ufazien Hosting')) {
+        const ufazienSection = `
+
+---
+
+## Ufazien Deployment
+
+This project is configured for deployment to Ufazien Hosting.
+
+### Build and Deploy
+
+1. Build your project (this will create a \`dist\` or \`build\` folder):
+\`\`\`bash
+npm run build
+# or
+yarn build
+# or
+pnpm build
+\`\`\`
+
+2. Deploy to Ufazien:
+\`\`\`bash
+ufazienjs deploy
+\`\`\`
+
+The deployment will automatically upload the contents of your build folder.
+`;
+        fs.appendFileSync(readmePath, ufazienSection);
+      }
+    }
+  } else {
+    // For PHP and Static projects
+    if (!fs.existsSync(readmePath)) {
+      const readmeContent = `# ${websiteName}
+
+This project is configured for deployment to Ufazien Hosting.
+
+## Deploy
+
+Deploy your website to Ufazien:
+
+\`\`\`bash
+ufazienjs deploy
+\`\`\`
+
+Your website will be available at your configured subdomain.
+`;
+      fs.writeFileSync(readmePath, readmeContent);
+    } else {
+      const existingContent = fs.readFileSync(readmePath, 'utf-8');
+      if (!existingContent.includes('Ufazien Hosting')) {
+        const ufazienSection = `
+
+---
+
+## Ufazien Deployment
+
+This project is configured for deployment to Ufazien Hosting.
+
+### Deploy
+
+Deploy your website to Ufazien:
+
+\`\`\`bash
+ufazienjs deploy
+\`\`\`
+
+Your website will be available at your configured subdomain.
+`;
+        fs.appendFileSync(readmePath, ufazienSection);
+      }
+    }
+  }
+}
+
 export function createUfazienignore(projectDir: string): void {
   const ufazienignoreContent = `# Files and directories to exclude from deployment
 .git/

--- a/ufazien-cli-py/pyproject.toml
+++ b/ufazien-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ufazien-cli"
-version = "0.2.1"
+version = "0.3.0"
 description = "Command-line interface for deploying web applications on Ufazien platform"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/ufazien-cli-py/src/ufazien/__init__.py
+++ b/ufazien-cli-py/src/ufazien/__init__.py
@@ -2,7 +2,7 @@
 Ufazien CLI - Command-line interface for deploying web applications on Ufazien platform.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 from ufazien.client import UfazienAPIClient
 

--- a/ufazien-cli-py/src/ufazien/project.py
+++ b/ufazien-cli-py/src/ufazien/project.py
@@ -162,6 +162,119 @@ build/
                 f.write('\n' + '\n'.join(additions) + '\n')
 
 
+def create_readme_section(project_dir: str, website_type: str, website_name: str, build_folder: Optional[str] = None) -> None:
+    """Create or append README.md with Ufazien deployment section."""
+    project_path = Path(project_dir)
+    readme_path = project_path / 'README.md'
+    
+    if website_type == 'build':
+        # For build projects, use the existing create_build_project_structure logic
+        if not readme_path.exists():
+            readme_content = f"""# {website_name}
+
+This project is configured for deployment to Ufazien Hosting.
+
+## Build and Deploy
+
+1. Build your project (this will create a `dist` or `build` folder):
+```bash
+npm run build
+# or
+yarn build
+# or
+pnpm build
+```
+
+2. Deploy to Ufazien:
+```bash
+ufazien deploy
+```
+
+The deployment will automatically upload the contents of your build folder.
+"""
+            with open(readme_path, 'w', encoding='utf-8') as f:
+                f.write(readme_content)
+        else:
+            # Append Ufazien deployment section to existing README
+            with open(readme_path, 'r', encoding='utf-8') as f:
+                existing_content = f.read()
+            
+            if 'Ufazien Hosting' not in existing_content:
+                ufazien_section = f"""
+
+---
+
+## Ufazien Deployment
+
+This project is configured for deployment to Ufazien Hosting.
+
+### Build and Deploy
+
+1. Build your project (this will create a `dist` or `build` folder):
+```bash
+npm run build
+# or
+yarn build
+# or
+pnpm build
+```
+
+2. Deploy to Ufazien:
+```bash
+ufazien deploy
+```
+
+The deployment will automatically upload the contents of your build folder.
+"""
+                with open(readme_path, 'a', encoding='utf-8') as f:
+                    f.write(ufazien_section)
+    else:
+        # For PHP and Static projects, append a simple deployment section
+        if not readme_path.exists():
+            readme_content = f"""# {website_name}
+
+This project is configured for deployment to Ufazien Hosting.
+
+## Deploy
+
+Deploy your website to Ufazien:
+
+```bash
+ufazien deploy
+```
+
+Your website will be available at your configured subdomain.
+"""
+            with open(readme_path, 'w', encoding='utf-8') as f:
+                f.write(readme_content)
+        else:
+            # Append Ufazien deployment section to existing README
+            with open(readme_path, 'r', encoding='utf-8') as f:
+                existing_content = f.read()
+            
+            if 'Ufazien Hosting' not in existing_content:
+                ufazien_section = f"""
+
+---
+
+## Ufazien Deployment
+
+This project is configured for deployment to Ufazien Hosting.
+
+### Deploy
+
+Deploy your website to Ufazien:
+
+```bash
+ufazien deploy
+```
+
+Your website will be available at your configured subdomain.
+"""
+                with open(readme_path, 'a', encoding='utf-8') as f:
+                    f.write(ufazien_section)
+
+
 def create_ufazienignore(project_dir: str) -> None:
     """Create .ufazienignore file."""
     ufazienignore_content = """# Files and directories to exclude from deployment


### PR DESCRIPTION
This pull request introduces a more flexible and user-friendly project initialization workflow for both the JavaScript and Python versions of the Ufazien CLI. The main improvements are: always generating essential files (such as `.gitignore` and a Ufazien-specific section in `README.md`), prompting the user to optionally create the full project structure, and enhancing how deployment instructions are documented. The changes also ensure version numbers are updated across both CLI packages.

**User Experience Improvements:**

* The CLI now always creates essential files (`.gitignore` and a Ufazien deployment section in `README.md`), even if the user opts out of creating the full project structure. This ensures users always have basic deployment instructions and ignore rules in place. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL342-R361) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L276-R287) [[3]](diffhunk://#diff-7c9f21c5df86ca70cf84e4a6f576bd607f38f8ed506cd51889c9439bbab95044R167-R276) [[4]](diffhunk://#diff-26692dbf6dc4be638c98964bc7fd77f83728a3b2ad69eb2bd79bba3ec56309bfR165-R277)
* Users are prompted to choose whether to generate the full project structure, making the initialization process more flexible and less intrusive. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL342-R361) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L276-R287)

**README.md and Documentation Enhancements:**

* Added a new helper (`createReadmeSection` / `create_readme_section`) that creates or appends a Ufazien deployment section to `README.md`, tailored for the project type (build, PHP, or static). This ensures deployment instructions are always present and up-to-date. [[1]](diffhunk://#diff-7c9f21c5df86ca70cf84e4a6f576bd607f38f8ed506cd51889c9439bbab95044R167-R276) [[2]](diffhunk://#diff-26692dbf6dc4be638c98964bc7fd77f83728a3b2ad69eb2bd79bba3ec56309bfR165-R277)
* If a `README.md` already exists, the Ufazien deployment section is appended only if it doesn't already exist, preventing duplication. [[1]](diffhunk://#diff-7c9f21c5df86ca70cf84e4a6f576bd607f38f8ed506cd51889c9439bbab95044R167-R276) [[2]](diffhunk://#diff-26692dbf6dc4be638c98964bc7fd77f83728a3b2ad69eb2bd79bba3ec56309bfR165-R277)

**Project Structure and File Generation Logic:**

* The logic for creating `.env`, `.ufazienignore`, and `config.php` files has been clarified and streamlined, with clear separation between essential files (always created) and boilerplate files (created only if the user opts in). [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bR373-L370) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L293-L325)
* The build project type is handled more cleanly, ensuring unnecessary files are not created and that deployment instructions are clear. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL380-R427) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L293-L325)

**Version Updates:**

* Bumped the version numbers for both the JavaScript and Python CLI packages to `0.3.0` to reflect these new features. [[1]](diffhunk://#diff-92edcad5a7bbc0843eebe0cbdb06f4f69a631acfc4dc99ec3e87e194c8172a9cL3-R9) [[2]](diffhunk://#diff-648bcfa8f9d6ebbfae03c8d1f388c2f5b18a5cb6d16a979062306babadd244b3L3-R3) [[3]](diffhunk://#diff-e1e0e9c74e366e9300694042b6fc6082c6859c06c83fae0eda50e680e187b244L7-R7) [[4]](diffhunk://#diff-527b11ece2f7ed237c5080959c506323ee69914582255db258c3debd980ef956L5-R5)

**Codebase Consistency:**

* Both the JavaScript and Python CLIs now follow a consistent workflow and user experience for project initialization and documentation. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL342-R361) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L276-R287)

---

**Most important changes:**

_User Experience & Workflow:_
- Always create essential files (`.gitignore`, Ufazien deployment section in `README.md`) regardless of project structure choice; prompt user to optionally create full project structure. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL342-R361) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L276-R287)

_Documentation:_
- Added `createReadmeSection`/`create_readme_section` to generate or append Ufazien deployment instructions to `README.md`, tailored by project type and avoiding duplication. [[1]](diffhunk://#diff-7c9f21c5df86ca70cf84e4a6f576bd607f38f8ed506cd51889c9439bbab95044R167-R276) [[2]](diffhunk://#diff-26692dbf6dc4be638c98964bc7fd77f83728a3b2ad69eb2bd79bba3ec56309bfR165-R277)

_Project Structure Logic:_
- Improved logic for creating `.env`, `.ufazienignore`, and `config.php` files, with clear separation between essential and optional boilerplate files. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bR373-L370) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L293-L325)
- Cleaned up handling of build projects to avoid unnecessary files and clarify deployment instructions. [[1]](diffhunk://#diff-078118fa2c214e39bb640857d11efaee14e3a44d2d3a8c28bfe15e7abfee619bL380-R427) [[2]](diffhunk://#diff-4bfce22c3d44e5ad59f4da51cc278adfe120bb47d63be347994036c7d3267b44L293-L325)

_Versioning:_
- Updated version numbers for both CLI packages to `0.3.0`. [[1]](diffhunk://#diff-92edcad5a7bbc0843eebe0cbdb06f4f69a631acfc4dc99ec3e87e194c8172a9cL3-R9) [[2]](diffhunk://#diff-648bcfa8f9d6ebbfae03c8d1f388c2f5b18a5cb6d16a979062306babadd244b3L3-R3) [[3]](diffhunk://#diff-e1e0e9c74e366e9300694042b6fc6082c6859c06c83fae0eda50e680e187b244L7-R7) [[4]](diffhunk://#diff-527b11ece2f7ed237c5080959c506323ee69914582255db258c3debd980ef956L5-R5)