### PR TITLE
Fix .ufazienignore matching and switch publish workflows to trusted publishing

### DIFF
--- a/.github/workflows/publish_npm_pkg.yml
+++ b/.github/workflows/publish_npm_pkg.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a version that supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         working-directory: ./ufazien-cli-js
@@ -30,8 +33,6 @@ jobs:
         working-directory: ./ufazien-cli-js
         run: npm run build
 
-      - name: Publish to npm
+      - name: Publish to npm (trusted publisher, with provenance)
         working-directory: ./ufazien-cli-js
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish_python_pkg.yml
+++ b/.github/workflows/publish_python_pkg.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read
       id-token: write
@@ -24,17 +25,13 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
       - name: Build package
         working-directory: ./ufazien-cli-py
-        run: |
-          python -m build
+        run: python -m build
 
-      - name: Publish to PyPI
-        working-directory: ./ufazien-cli-py
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python -m twine upload dist/*
+      - name: Publish to PyPI (trusted publisher, OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ufazien-cli-py/dist

--- a/ufazien-cli-js/package-lock.json
+++ b/ufazien-cli-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ufazien-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ufazien-cli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",

--- a/ufazien-cli-js/package.json
+++ b/ufazien-cli-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ufazien-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/ufazien-cli-js/src/utils.ts
+++ b/ufazien-cli-js/src/utils.ts
@@ -41,7 +41,11 @@ export function saveWebsiteConfig(projectDir: string, config: WebsiteConfig): vo
   }
 }
 
-export function shouldExcludeFile(filePath: string, ufazienignorePath: string): boolean {
+export function shouldExcludeFile(
+  filePath: string,
+  projectRoot: string,
+  ufazienignorePath: string
+): boolean {
   if (!fs.existsSync(ufazienignorePath)) {
     return false;
   }
@@ -52,11 +56,30 @@ export function shouldExcludeFile(filePath: string, ufazienignorePath: string): 
     .map((line) => line.trim())
     .filter((line) => line && !line.startsWith('#'));
 
+  const relPath = path.relative(projectRoot, filePath).split(path.sep).join('/');
+  if (!relPath || relPath.startsWith('..')) {
+    return false;
+  }
+  const segments = relPath.split('/');
+  const basename = segments[segments.length - 1];
+
   for (const pattern of ignorePatterns) {
-    if (filePath.includes(pattern) || filePath.endsWith(pattern)) {
-      return true;
+    if (pattern.endsWith('/')) {
+      const dir = pattern.slice(0, -1);
+      if (dir && segments.includes(dir)) {
+        return true;
+      }
+      continue;
     }
-    if (pattern.endsWith('/') && filePath.startsWith(pattern)) {
+
+    if (pattern.startsWith('*.') && !pattern.slice(2).includes('*')) {
+      if (basename.endsWith(pattern.slice(1))) {
+        return true;
+      }
+      continue;
+    }
+
+    if (basename === pattern || relPath === pattern) {
       return true;
     }
   }

--- a/ufazien-cli-js/src/zip.ts
+++ b/ufazien-cli-js/src/zip.ts
@@ -46,7 +46,7 @@ export async function createZip(projectDir: string, outputPath?: string): Promis
         }
 
         // Check if should be excluded
-        if (shouldExcludeFile(filePath, ufazienignorePath)) {
+        if (shouldExcludeFile(filePath, projectPath, ufazienignorePath)) {
           continue;
         }
 

--- a/ufazien-cli-py/pyproject.toml
+++ b/ufazien-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ufazien-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Command-line interface for deploying web applications on Ufazien platform"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/ufazien-cli-py/src/ufazien/__init__.py
+++ b/ufazien-cli-py/src/ufazien/__init__.py
@@ -2,7 +2,7 @@
 Ufazien CLI - Command-line interface for deploying web applications on Ufazien platform.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from ufazien.client import UfazienAPIClient
 

--- a/ufazien-cli-py/src/ufazien/utils.py
+++ b/ufazien-cli-py/src/ufazien/utils.py
@@ -77,7 +77,7 @@ def save_website_config(project_dir: str, config: Dict[str, Any]) -> None:
                 f.write('\n.ufazien.json\n')
 
 
-def should_exclude_file(file_path: Path, ufazienignore_path: Path) -> bool:
+def should_exclude_file(file_path: Path, project_root: Path, ufazienignore_path: Path) -> bool:
     """Check if a file should be excluded based on .ufazienignore."""
     if not ufazienignore_path.exists():
         return False
@@ -85,11 +85,30 @@ def should_exclude_file(file_path: Path, ufazienignore_path: Path) -> bool:
     with open(ufazienignore_path, 'r') as f:
         ignore_patterns = [line.strip() for line in f if line.strip() and not line.strip().startswith('#')]
 
-    file_str = str(file_path)
+    try:
+        rel = file_path.relative_to(project_root)
+    except ValueError:
+        return False
+
+    rel_path = rel.as_posix()
+    if not rel_path or rel_path == '.':
+        return False
+    segments = rel_path.split('/')
+    basename = segments[-1]
+
     for pattern in ignore_patterns:
-        if pattern in file_str or file_str.endswith(pattern):
-            return True
-        if pattern.endswith('/') and file_str.startswith(pattern):
+        if pattern.endswith('/'):
+            dir_name = pattern[:-1]
+            if dir_name and dir_name in segments:
+                return True
+            continue
+
+        if pattern.startswith('*.') and '*' not in pattern[2:]:
+            if basename.endswith(pattern[1:]):
+                return True
+            continue
+
+        if basename == pattern or rel_path == pattern:
             return True
 
     return False
@@ -107,13 +126,13 @@ def create_zip(project_dir: str, output_path: Optional[str] = None) -> str:
     with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk(project_path):
             dirs[:] = [d for d in dirs if not should_exclude_file(
-                Path(root) / d, ufazienignore_path
+                Path(root) / d, project_path, ufazienignore_path
             )]
 
             for file in files:
                 file_path = Path(root) / file
 
-                if should_exclude_file(file_path, ufazienignore_path):
+                if should_exclude_file(file_path, project_path, ufazienignore_path):
                     continue
 
                 if file_path.suffix == '.zip' and file_path.name == Path(output_path).name:


### PR DESCRIPTION
## Summary

- **Fix `.ufazienignore` matching** in both the npm and Python packages. Directory patterns like `docs/` / `.claude/` never matched on Windows because the matcher compared absolute paths with OS separators against forward-slash patterns, and `*.ext` wildcards silently failed because the substring check could never hit. Both packages now compute a forward-slash path relative to the project root and match by path segment, basename extension, or exact basename / relative path.
- **Bump both packages to 0.3.1** (patch — bug fix only, no API change to deploy users).
- **Switch publish workflows to OIDC trusted publishing**: npm publishes with `--provenance` and no `NPM_TOKEN`; PyPI uses `pypa/gh-action-pypi-publish` with no `PYPI_API_TOKEN`.

## Required follow-up (out of code)

Before the next release, configure trusted publishers:

- **npm**: on npmjs.com → `ufazien-cli` package settings → Trusted Publishers → add this repo, workflow `publish_npm_pkg.yml`.
- **PyPI**: on pypi.org → `ufazien-cli` project → Publishing → add this repo, workflow `publish_python_pkg.yml`, environment `pypi`. Also create a `pypi` environment in GitHub repo settings.

Once configured, the existing `NPM_TOKEN` and `PYPI_API_TOKEN` secrets can be removed.

## Test plan

- [x] Functional test of `should_exclude_file` (Python) — `docs/`, `.claude/`, `*.log` all excluded; `src/` and `README.md` kept; zip contents verified.
- [x] Functional test of `shouldExcludeFile` (JS) — same patterns, same expected outcome; zip contents verified.
- [x] `tsc --noEmit` passes on the npm package.
- [ ] First release after merge: verify npm publish succeeds via OIDC (after configuring trusted publisher).
- [ ] First release after merge: verify PyPI publish succeeds via OIDC (after configuring trusted publisher).