### PR TITLE
Rewrite top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,165 +1,174 @@
-# Ufazien CLI
+<h1 align="center">Ufazien CLI</h1>
 
-🚀 Command-line interface for deploying web applications on the Ufazien platform.
+<p align="center">
+  Deploy static sites, PHP apps, and build-output projects to the <a href="https://ufazien.com">Ufazien</a> platform from your terminal — in either Python or Node.
+</p>
 
-This repository contains **two official CLI packages** for the Ufazien platform:
+<p align="center">
+  <a href="https://pypi.org/project/ufazien-cli/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/ufazien-cli?label=pypi&logo=pypi&logoColor=white&color=3775A9"></a>
+  <a href="https://www.npmjs.com/package/ufazien-cli"><img alt="npm version" src="https://img.shields.io/npm/v/ufazien-cli?label=npm&logo=npm&logoColor=white&color=CB3837"></a>
+  <a href="https://pypi.org/project/ufazien-cli/"><img alt="PyPI downloads" src="https://img.shields.io/pypi/dm/ufazien-cli?label=pypi%20downloads&color=3775A9"></a>
+  <a href="https://www.npmjs.com/package/ufazien-cli"><img alt="npm downloads" src="https://img.shields.io/npm/dm/ufazien-cli?label=npm%20downloads&color=CB3837"></a>
+  <img alt="License" src="https://img.shields.io/badge/license-MIT-green">
+  <a href="https://github.com/martian56/ufazien-cli/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/martian56/ufazien-cli?style=flat&logo=github"></a>
+  <a href="https://github.com/martian56/ufazien-cli/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/martian56/ufazien-cli/test_npm_package.yml?label=npm%20tests&logo=github"></a>
+  <a href="https://github.com/martian56/ufazien-cli/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/martian56/ufazien-cli/test_python_pkg.yml?label=python%20tests&logo=github"></a>
+</p>
 
-- **Python Package** (`ufazien-cli-py`) - Install via PyPI
-- **JavaScript/TypeScript Package** (`ufazien-cli-js`) - Install via npm
-
-Both packages provide the same functionality
 ---
 
-## 📦 Installation
+## Overview
 
-### Python Package (Recommended for Python users)
+This repository ships two officially-supported CLIs that talk to the same Ufazien deployment API:
+
+| Package | Install | Command | Registry |
+| ------- | ------- | ------- | -------- |
+| `ufazien-cli` (Python) | `pip install ufazien-cli` | `ufazien` | [PyPI](https://pypi.org/project/ufazien-cli/) |
+| `ufazien-cli` (Node)   | `npm install -g ufazien-cli` | `ufazienjs` | [npm](https://www.npmjs.com/package/ufazien-cli) |
+
+Pick the one that fits your stack — both expose the same commands and behaviour.
+
+---
+
+## Quick start
 
 ```bash
-pip install ufazien-cli
+# 1. install (pick one)
+pip install ufazien-cli       # → `ufazien`
+npm install -g ufazien-cli    # → `ufazienjs`
+
+# 2. authenticate
+ufazien login                 # or: ufazienjs login
+
+# 3. scaffold a project in the current directory
+ufazien create                # or: ufazienjs create
+
+# 4. ship it
+ufazien deploy                # or: ufazienjs deploy
 ```
 
-After installation, use the `ufazien` command:
+`create` walks you through the website name, subdomain, project type (`static`, `php`, or `build`), and — for PHP projects — provisions a database. `deploy` zips your project (respecting `.ufazienignore`) and uploads it to your site.
+
+---
+
+## Project types
+
+| Type | What it deploys | Typical use |
+| ---- | --------------- | ----------- |
+| **static** | The project root, minus paths in `.ufazienignore`. | Plain HTML/CSS/JS sites. |
+| **php**    | The project root, minus paths in `.ufazienignore`, plus an `.env` if you provisioned a database. | PHP apps (with optional managed MySQL). |
+| **build**  | The contents of your configured build folder (e.g. `dist/`, `build/`). | Vite, React, Vue, Svelte, and other framework builds. |
+
+### `.ufazienignore`
+
+A gitignore-style exclude list for the deploy zip. Generated automatically for `static` and `php` projects. Supports:
+
+- `dir/` — exclude a directory anywhere in the tree
+- `*.ext` — exclude files by extension
+- `name` or `path/to/file` — exclude by basename or relative path
+
+---
+
+## Commands
+
+| Command | Description |
+| ------- | ----------- |
+| `login`  | Authenticate against the Ufazien API and persist a session token. |
+| `logout` | Clear the local session. |
+| `status` | Show the signed-in account and current session info. |
+| `create` | Interactively scaffold a new website project + register it on Ufazien. |
+| `deploy` | Package the current project and push it to your site. |
+
+Run `--help` on any command for flags.
+
+---
+
+## Local development
 
 ```bash
+git clone https://github.com/martian56/ufazien-cli.git
+cd ufazien-cli
+```
+
+**Python package** (`ufazien-cli-py/`):
+
+```bash
+cd ufazien-cli-py
+python -m venv venv && source venv/bin/activate   # (Windows: venv\Scripts\activate)
+pip install -e ".[dev]"
 ufazien --help
 ```
 
-**Features:**
-- ✨ Beautiful terminal UI powered by [Rich](https://github.com/Textualize/rich)
-- 🎯 Modern CLI framework using [Typer](https://github.com/tiangolo/typer)
-- 📦 Available on [PyPI](https://pypi.org/project/ufazien-cli/)
-
-### JavaScript/TypeScript Package (Recommended for Node.js users)
+**Node package** (`ufazien-cli-js/`):
 
 ```bash
-npm install -g ufazien-cli
+cd ufazien-cli-js
+npm install
+npm run build
+node dist/cli.js --help
+# or, for live reload during development:
+npm run dev -- --help
 ```
 
-After installation, use the `ufazienjs` command:
-
-```bash
-ufazienjs --help
-```
-
-**Features:**
-- ✨ Beautiful terminal UI with colors and prompts
-- 🎯 Modern CLI framework using Commander.js
-- 📦 Available on [npm](https://www.npmjs.com/package/ufazien-cli)
-- 🔷 Built with TypeScript
+Each package has its own README with package-specific details.
 
 ---
 
-## 🚀 Quick Start
+## Built with
 
-### 1. Login
-
-**Python:**
-```bash
-ufazien login
-```
-
-**JavaScript:**
-```bash
-ufazienjs login
-```
-
-You'll be prompted for your email and password
-
-### 2. Create a Website
-
-Navigate to your project directory and run:
-
-**Python:**
-```bash
-ufazien create
-```
-
-**JavaScript:**
-```bash
-ufazienjs create
-```
-
-The CLI will guide you through:
-- Website name and subdomain
-- Website type (Static, PHP, or Build)
-- Database creation (for PHP projects)
-- Build folder name (for Build projects)
-- Project structure generation
-
-### 3. Deploy Your Website
-
-From your project directory:
-
-**Python:**
-```bash
-ufazien deploy
-```
-
-**JavaScript:**
-```bash
-ufazienjs deploy
-```
-
-This will:
-1. Create a ZIP archive (excluding files in `.ufazienignore`)
-2. Upload files to your website
-3. Trigger deployment
-
-### 4. Check Status
-
-**Python:**
-```bash
-ufazien status
-```
-
-**JavaScript:**
-```bash
-ufazienjs status
-```
-
-### 5. Logout
-
-**Python:**
-```bash
-ufazien logout
-```
-
-**JavaScript:**
-```bash
-ufazienjs logout
-```
+[![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
+[![Typer](https://img.shields.io/badge/Typer-009485?style=for-the-badge&logo=typer&logoColor=white)](https://typer.tiangolo.com/)
+[![Rich](https://img.shields.io/badge/Rich-FAE742?style=for-the-badge&logo=python&logoColor=black)](https://github.com/Textualize/rich)
+[![Requests](https://img.shields.io/badge/Requests-005571?style=for-the-badge&logo=python&logoColor=white)](https://requests.readthedocs.io/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org/)
+[![Commander](https://img.shields.io/badge/Commander.js-1F425F?style=for-the-badge&logo=node.js&logoColor=white)](https://github.com/tj/commander.js)
+[![Inquirer](https://img.shields.io/badge/Inquirer-3B82F6?style=for-the-badge&logo=node.js&logoColor=white)](https://github.com/SBoudrias/Inquirer.js)
+[![Chalk](https://img.shields.io/badge/Chalk-2E2E2E?style=for-the-badge&logo=npm&logoColor=white)](https://github.com/chalk/chalk)
+[![Axios](https://img.shields.io/badge/Axios-5A29E4?style=for-the-badge&logo=axios&logoColor=white)](https://axios-http.com/)
 
 ---
 
-## 📋 Available Commands
+## Contributing
 
-| Command | Description |
-|---------|-------------|
-| `login` | Login to your Ufazien account |
-| `logout` | Logout from your account |
-| `create` | Create a new website project |
-| `deploy` | Deploy your website |
-| `status` | Check login status and profile |
+Issues and pull requests are welcome. If you're filing a bug, please include:
 
----
+- which package you're using (`ufazien-cli` Python or Node) and its version
+- the command you ran and the output you got
+- your OS
 
-## 🆘 Support
-
-For issues and questions:
-- **GitHub Issues**: [https://github.com/martian56/ufazien-cli/issues](https://github.com/martian56/ufazien-cli/issues)
-- **Ufazien Support**: [https://ufazien.com/support](https://ufazien.com/support)
+For larger changes, open an issue first to discuss the approach.
 
 ---
 
-## 📄 License
+## Repo activity
 
-MIT License
+<!--
+  Generate the embed URL at https://repobeats.axiom.co (sign in with GitHub,
+  pick this repo, copy the SVG embed URL) and replace the placeholder below.
+-->
+![Repo activity](https://repobeats.axiom.co/api/embed/REPLACE_WITH_REPOBEATS_HASH.svg "Repobeats analytics image")
+
+## Contributors
+
+<a href="https://github.com/martian56/ufazien-cli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=martian56/ufazien-cli" alt="Contributors"/>
+</a>
+
+## Star history
+
+[![Star History Chart](https://api.star-history.com/svg?repos=martian56/ufazien-cli&type=Date)](https://www.star-history.com/#martian56/ufazien-cli&Date)
 
 ---
 
-## 🔗 Links
+## Links
 
-- **Homepage**: [https://ufazien.com](https://ufazien.com)
-- **Python Package**: [https://pypi.org/project/ufazien-cli/](https://pypi.org/project/ufazien-cli/)
-- **npm Package**: [https://www.npmjs.com/package/ufazien-cli](https://www.npmjs.com/package/ufazien-cli)
-- **Repository**: [https://github.com/martian56/ufazien-cli](https://github.com/martian56/ufazien-cli)
+- Homepage — [ufazien.com](https://ufazien.com)
+- Documentation — [howtohoston.ufazien.com](https://howtohoston.ufazien.com)
+- PyPI — [pypi.org/project/ufazien-cli](https://pypi.org/project/ufazien-cli/)
+- npm — [npmjs.com/package/ufazien-cli](https://www.npmjs.com/package/ufazien-cli)
+- Issues — [github.com/martian56/ufazien-cli/issues](https://github.com/martian56/ufazien-cli/issues)
+
+## License
+
+Released under the MIT License.


### PR DESCRIPTION
## Summary

Rewrites the top-level `README.md` from a marketing-tinted feature list into a structured project page modelled on the layout of a typical OSS repo.

What changed:

- **Header** — centered title, one-line elevator pitch, and a row of badges (PyPI version, npm version, monthly downloads for each, MIT license, GitHub stars, test-workflow status for both packages).
- **Overview** — a two-row table making the Python-vs-Node split unambiguous (install command, CLI name, registry link).
- **Quick start** — five-line copy-pasteable block covering install → login → create → deploy.
- **Project types** — table for `static` / `php` / `build` plus a short `.ufazienignore` reference aligned with the fixed matcher (directory, extension, and basename forms).
- **Commands** — kept the table, dropped the per-package duplication.
- **Local development** — concrete clone-and-run steps for both packages.
- **Built with** — `shields.io` for-the-badge row for Python/Typer/Rich/Requests and TypeScript/Node/Commander/Inquirer/Chalk/Axios.
- **Repo activity / Contributors / Star history** — Repobeats embed, `contrib.rocks` contributor avatars, `star-history.com` chart.
- **License** — dropped a link to a non-existent `LICENSE` file, switched the license badge to a static MIT badge.

## Required follow-up (not done in this PR)

- **Repobeats hash** — the activity image URL has a `REPLACE_WITH_REPOBEATS_HASH` placeholder. Sign in at https://repobeats.axiom.co with GitHub, pick this repo, paste the generated SVG URL in. There's an HTML comment in the README pointing at this.
- **`LICENSE` file** — the package metadata declares MIT but the repo has no `LICENSE` file. Worth adding one in a follow-up so the badge and metadata aren't aspirational.

## Test plan

- [x] Renders correctly on GitHub (badges resolve, tables render, contributors/star-history images load).
- [ ] After merging: confirm Repobeats embed renders once the hash is filled in.